### PR TITLE
mod_quizgame: Update Travis file to support Moodle 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 
 addons:
   firefox: "47.0.1"
-  postgresql: "9.3"
+  postgresql: "9.4"
   apt:
     packages:
       - oracle-java8-installer
@@ -16,11 +16,11 @@ cache:
     - $HOME/.npm
 
 php:
- - 7.0
  - 7.1
+ - 7.2
 
 addons:
-  postgresql: 9.3
+  postgresql: 9.4
 
 env:
  matrix:


### PR DESCRIPTION
Moodle 3.7 has raised the system requirements to install Moodle.  As a result, the travis builds against the master branch (Moodle 3.7) fail.  This PR updates the travis.yml file to use PHP 7.1 and Postgresql 9.4 which are the minimum requirements for Moodle 3.7